### PR TITLE
change to be compatible with php 8.1

### DIFF
--- a/src/FileSize.php
+++ b/src/FileSize.php
@@ -13,7 +13,7 @@ class FileSize extends Field
      */
     public $component = 'fileSize';
 
-    public function __construct(string $name, ?string $attribute = null, ?mixed $resolveCallback = null)
+    public function __construct(string $name, ?string $attribute = null, mixed $resolveCallback = null)
     {
         parent::__construct($name, $attribute, $resolveCallback);
     }


### PR DESCRIPTION
Type mixed cannot be marked as nullable since mixed already includes null https://github.com/itiden/nova-file-size-field/issues/4